### PR TITLE
Remove deploy step in Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,3 @@ rvm:
 
 cache: bundler
 script: bundle exec middleman build
-
-
-deploy:
-  provider: pages
-  skip_cleanup: true
-  github_token: $github_token
-  local_dir: build
-  on:
-    branch: master


### PR DESCRIPTION
The site will be manually deployed to other repo for the time being.