### PR TITLE
Ignore Eclipse files and node_modules dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,11 @@ build/
 _yardoc
 doc/
 .idea/
+
+# Eclipse
+*.project
+*.settings
+
+# JS
+node_modules/
+dist/


### PR DESCRIPTION
Ignore Eclipse files and `node_modules` dir (created when converting the
OpenAPI definition with `widdershins`).