### PR TITLE
Update links to live site

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ applications. ZAP also has an extremely powerful API that allows you to do nearl
 This allows the developers to automate pentesting and security regression testing of the application in the CI/CD pipeline.
 This repository provides example guides & API definitions for ZAP APIs.
 
-The live demo can be viewed in the following [URL](https://zaproxy.github.io/zap-api-docs).
+The live demo can be viewed in the following [URL](https://zaproxy.org/docs/api/).
 
 # Contributing to the Documentation
 
-The guidelines for contribution is available in the [following page](https://zaproxy.github.io/zap-api-docs/#contributions-welcome).
+The guidelines for contribution is available in the [following page](https://zaproxy.org/docs/api/#contributions-welcome).
 ZAP documentation is built using [Slate](https://github.com/tripit/slate). The source files for the documentation are available 
 in the `source/includes` directory. View the contribution guide on how to start contributing to the document.


### PR DESCRIPTION
Link to `zaproxy.org/docs/api` instead.