### PR TITLE
Removed links to zaproxy.org and owasp-academy.teachable.com

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -7,9 +7,7 @@ language_tabs: # must be one of https://git.io/vQNgJ
   - shell
 
 toc_footers:
-  - <a href='https://www.zaproxy.org/'>ZAP Org</a>
   - <a href='https://github.com/zaproxy/zaproxy/wiki'>ZAP Wiki</a>
-  - <a href='https://owasp-academy.teachable.com/p/owasp-zap-tutorial'>ZAP Tutorials</a>
 
 includes:
   - welcome


### PR DESCRIPTION
Signed-off-by: Simon Bennetts <psiinon@gmail.com>