### PR TITLE
Add list of API clients available

### DIFF
--- a/source/includes/welcome.md
+++ b/source/includes/welcome.md
@@ -89,8 +89,16 @@ that are able to use ZAP as a proxy, access to the API.
 
 ### Client SDKs
 
-ZAP provides official clients for many languages such as Python, Java, NodeJS, and .Net. Visit the following link to 
-view and download all supported [SDKs](https://github.com/zaproxy/zaproxy/wiki/ApiDetails). 
+API clients are available for the following languages:
+
+| **Language** | **Download links** | **Notes** |
+|:-------------|:-------------------|:----------|
+| .NET         | [NuGet](https://www.nuget.org/packages/OWASPZAPDotNetAPI) | Official API |
+| Java         | [GitHub](https://github.com/zaproxy/zap-api-java/releases) [Maven Central](https://search.maven.org/search?q=g:org.zaproxy%20AND%20a:zap-clientapi&core=gav) | Official API  |
+| Node.js      | [NPM](https://www.npmjs.org/package/zaproxy) | Official API |
+| PHP          | [GitHub](https://github.com/yukisov/php-owasp-zap-v2) [Packagist](https://packagist.org/packages/zaproxy/php-owasp-zap-v2)  | In process of becoming an official API |
+| Python       | [PyPI](https://pypi.python.org/pypi/python-owasp-zap-v2.4) | Official API  |
+| Ruby         | [GitHub](https://github.com/vpereira/owasp_zap) |           |
 
 ## Quick Setup Guide
 


### PR DESCRIPTION
Instead of linking to the wiki page, which now links to these docs.