### PR TITLE
Adding the troubleshooting section

### DIFF
--- a/source/includes/advanced.md
+++ b/source/includes/advanced.md
@@ -37,3 +37,12 @@ automatic tagging are provided by default. These can be changed, deleted or adde
 
 Content in progress!
 
+## Troubleshooting
+
+This section has troubleshooting procedures for the following problems that people may encounter with ZAP APIs:
+
+**No Implementor Error**
+
+- Check that the necessary addon or component is installed and enabled. (For example if you receive "no_implementor" in relation 
+to Ajax Spider calls, perhaps the Ajax Spider addon isn't installed.)
+


### PR DESCRIPTION
Fix for #14 
@kingthorin, I have added the troubleshooting section inside the advanced section, as we only have one point at the moment. Let's migrate to a new page when we have multiple listings.