### PR TITLE
Update Bundler to version 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+os: linux
 
 language: ruby
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,4 +128,4 @@ RUBY VERSION
    ruby 2.3.3p222
 
 BUNDLED WITH
-   1.17.3
+   2.1.4


### PR DESCRIPTION
Update to newer version to address build failures in Travis CI (the Ruby
and RubyGems versions being used are compatible with the newer Bundler
version).

Address warnings in Travis CI configuration:
 - Remove obsolete `sudo` configuration;
 - Declare the OS (`linux`).