### PR TITLE
Correct implementor name and other minor tweaks

### DIFF
--- a/source/includes/attack.md
+++ b/source/includes/attack.md
@@ -25,7 +25,7 @@ public class PassiveScan {
         
         try {
             // TODO : explore the app (Spider, etc) before using the Passive Scan API, Refer the explore section for details
-            // Loop until the ajax spider has finished or the timeout has exceeded
+            // Loop until the passive scan has finished
             while (true) {
                 Thread.sleep(2000);
                 api.pscan.recordsToScan();
@@ -61,7 +61,7 @@ zap = ZAPv2(apikey=apiKey, proxies={'http': 'http://127.0.0.1:8080', 'https': 'h
 
 # TODO : explore the app (Spider, etc) before using the Passive Scan API, Refer the explore section for details
 while int(zap.pscan.records_to_scan) > 0:
-    # Loop until the ajax spider has finished or the timeout has exceeded
+    # Loop until the passive scan has finished
     print('Records to passive scan : ' + zap.pscan.records_to_scan)
     time.sleep(2)
 
@@ -100,7 +100,7 @@ View the [advanced section](#passive-scan-settings) to know how to configure add
 ## Using Active Scan
 
 Active scanning attempts to find potential vulnerabilities by using known attacks against the selected targets. Active scanning 
-is an attack on those targets. You should **NOT** use it on applications that you do not own. 
+is an attack on those targets. You should **NOT** use it on applications that you do not have permission to. 
 
 ### Start Active Scanner
 

--- a/source/includes/explore.md
+++ b/source/includes/explore.md
@@ -233,19 +233,19 @@ public class AjaxSpider {
 
 ```shell
 # To start the Ajax Spider
-$ curl "http://localhost:8080/JSON/AjaxSpider/action/scan/?apikey=<ZAP_API_KEY>&url=<URL>&inScope=&contextName=&subtreeOnly="
+$ curl "http://localhost:8080/JSON/ajaxSpider/action/scan/?apikey=<ZAP_API_KEY>&url=<URL>&inScope=&contextName=&subtreeOnly="
 
 # To view the status
-$ curl "http://localhost:8080/JSON/AjaxSpider/view/status/?apikey=<ZAP_API_KEY>"
+$ curl "http://localhost:8080/JSON/ajaxSpider/view/status/?apikey=<ZAP_API_KEY>"
 
 # To view the number of results
-$ curl "http://localhost:8080/JSON/AjaxSpider/view/numberOfResults/?apikey=<ZAP_API_KEY>"
+$ curl "http://localhost:8080/JSON/ajaxSpider/view/numberOfResults/?apikey=<ZAP_API_KEY>"
 
 # To view the results
-$ curl "http://localhost:8080/JSON/AjaxSpider/view/fullResults/?apikey=<ZAP_API_KEY>"
+$ curl "http://localhost:8080/JSON/ajaxSpider/view/fullResults/?apikey=<ZAP_API_KEY>"
 
 # To stop the Ajax Spider
-$ curl "http://localhost:8080/JSON/AjaxSpider/action/stop/?apikey=<ZAP_API_KEY>"
+$ curl "http://localhost:8080/JSON/ajaxSpider/action/stop/?apikey=<ZAP_API_KEY>"
 ```
  
 Use the Ajax Spider if you have applications which heavily depend on Ajax or JavaScript. The Ajax Spider allows you to crawl web applications 


### PR DESCRIPTION
Correct the case of the AJAX Spider implementor name.
Correct code comments.
Reword message about attacking applications (say "permission to" instead
of "own").

---
From OWASP ZAP User Group: https://groups.google.com/d/msg/zaproxy-users/FowIUiN8duI/QibyA-UzBgAJ