### PR TITLE
Update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os: linux
 language: ruby
 
 rvm:
-  - 2.3.3
   - 2.4.0
 
 cache: bundler

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,10 @@
-ruby '>=2.3.1'
+ruby '>=2.4.0'
 source 'https://rubygems.org'
 
 # Middleman
-gem 'middleman', '~> 4.3.7'
+# Lock to 4.3.8 for now, 4.3.9 does not work correctly:
+# https://github.com/middleman/middleman/issues/2375
+gem 'middleman', '= 4.3.8'
 gem 'middleman-syntax', '~> 3.2.0'
 gem 'middleman-autoprefixer', '~> 2.10.1'
 gem 'middleman-sprockets', '~> 4.1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,27 +1,27 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.2.4.3)
+    activesupport (5.2.4.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
-    autoprefixer-rails (9.8.4)
+    autoprefixer-rails (9.8.6.3)
       execjs
-    backports (3.18.1)
+    backports (3.18.2)
     coffee-script (2.4.1)
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    concurrent-ruby (1.1.6)
+    concurrent-ruby (1.1.7)
     contracts (0.13.0)
-    dotenv (2.7.5)
+    dotenv (2.7.6)
     erubis (2.7.0)
     execjs (2.7.0)
     fast_blank (1.0.0)
-    fastimage (2.1.7)
+    fastimage (2.2.0)
     ffi (1.13.1)
     haml (5.1.2)
       temple (>= 0.8.0)
@@ -31,23 +31,24 @@ GEM
     hashie (3.6.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    kramdown (1.17.0)
+    kramdown (2.3.0)
+      rexml
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
     memoist (0.16.2)
-    middleman (4.3.7)
+    middleman (4.3.8)
       coffee-script (~> 2.2)
       haml (>= 4.0.5)
-      kramdown (~> 1.2)
-      middleman-cli (= 4.3.7)
-      middleman-core (= 4.3.7)
+      kramdown (>= 2.3.0)
+      middleman-cli (= 4.3.8)
+      middleman-core (= 4.3.8)
     middleman-autoprefixer (2.10.1)
       autoprefixer-rails (~> 9.1)
       middleman-core (>= 3.3.3)
-    middleman-cli (4.3.7)
+    middleman-cli (4.3.8)
       thor (>= 0.17.0, < 2.0)
-    middleman-core (4.3.7)
+    middleman-core (4.3.8)
       activesupport (>= 4.2, < 6.0)
       addressable (~> 2.3)
       backports (~> 3.6)
@@ -77,8 +78,8 @@ GEM
       middleman-core (>= 3.2)
       rouge (~> 3.2)
     mini_portile2 (2.4.0)
-    minitest (5.14.1)
-    nokogiri (1.10.9)
+    minitest (5.14.2)
+    nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
     padrino-helpers (0.13.3.4)
       i18n (~> 0.6, >= 0.6.7)
@@ -87,12 +88,13 @@ GEM
     padrino-support (0.13.3.4)
       activesupport (>= 3.1)
     parallel (1.19.2)
-    public_suffix (4.0.5)
+    public_suffix (4.0.6)
     rack (2.2.3)
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     redcarpet (3.5.0)
+    rexml (3.2.4)
     rouge (3.20.0)
     sass (3.4.25)
     sassc (2.4.0)
@@ -114,7 +116,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  middleman (~> 4.3.7)
+  middleman (= 4.3.8)
   middleman-autoprefixer (~> 2.10.1)
   middleman-sprockets (~> 4.1.1)
   middleman-syntax (~> 3.2.0)
@@ -125,7 +127,7 @@ DEPENDENCIES
   sprockets (= 3.7.2)
 
 RUBY VERSION
-   ruby 2.3.3p222
+   ruby 2.4.10p364
 
 BUNDLED WITH
    2.1.4


### PR DESCRIPTION
Update dependencies to latest versions, except `middleman` which is not
working correctly.

Update minimum Ruby version to 2.4.0.
Remove older Ruby version (2.3.3) from Travis CI configuration because
of incompatibilities with the newer versions of the dependencies (a
newer Ruby version is already being used to generate the site).

The generated content has not changed.