### PR TITLE
Adding CSS fix to align python and Java content

### DIFF
--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -618,3 +618,7 @@ html, body {
 .highlight, .highlight .w {
   background-color: $code-bg;
 }
+
+div.highlight {
+  clear: none;
+}


### PR DESCRIPTION
Signed-off-by: sshniro <sshniro@gmail.com>

Fix #43

The issue is mentioned here in this PR: https://github.com/slatedocs/slate/issues/1163

The following image shows the rendered results:
<img width="1263" alt="Screenshot 2020-10-16 at 10 55 37" src="https://user-images.githubusercontent.com/13045528/96237995-3dbd5600-0f9e-11eb-85ee-36672d7b7da5.png">
