### PR TITLE
Run CI checks with GitHub workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: Ruby CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.6
+        bundler-cache: true
+    - run: bundle exec middleman build

--- a/.github/workflows/update-website.yml
+++ b/.github/workflows/update-website.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Setup ruby
       uses: actions/setup-ruby@v1
       with:
-        ruby-version: '2.4'
+        ruby-version: '2.6'
     - name: Checkout
       uses: actions/checkout@v2
       with:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-os: linux
-
-language: ruby
-
-rvm:
-  - 2.4.0
-
-cache: bundler
-script: bundle exec middleman build

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-[![Build Status](https://travis-ci.com/zaproxy/zap-api-docs.svg?branch=master)](https://travis-ci.com/zaproxy/zap-api-docs)
 
 # Introduction
 


### PR DESCRIPTION
Add workflow to run CI checks with GitHub.
Remove Travis CI configuration.
Remove Travis CI reference in README.
Update Ruby version (to 2.6), needed for #52.