### PR TITLE
Fix setContextRegexs parameter type

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -6928,14 +6928,18 @@ paths:
         deprecated: false
         description: ""
         schema:
-          type: string
+          type: array
+          items:
+            type: string
       - name: excRegexs
         in: query
         required: true
         deprecated: false
         description: ""
         schema:
-          type: string
+          type: array
+          items:
+            type: string
   /JSON/context/action/newContext/:
     get:
       description: >-


### PR DESCRIPTION
The setContextRegexs action expects an array of strings for the incRegexs and excRegexs parameters. Update the documentation accordingly.