### PR TITLE
Update Ruby version in Update Website workflow

### DIFF
--- a/.github/workflows/update-website.yml
+++ b/.github/workflows/update-website.yml
@@ -9,16 +9,14 @@ jobs:
   update-website:
     runs-on: ubuntu-latest
     steps:
-    - name: Setup ruby
-      uses: actions/setup-ruby@v1
+    - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '2.6'
-    - name: Checkout
-      uses: actions/checkout@v2
+        ruby-version: 3.2
+    - uses: actions/checkout@v3
       with:
         path: zap-api-docs
     - name: Checkout zaproxy.github.io
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: zaproxy/zaproxy.github.io
         persist-credentials: false


### PR DESCRIPTION
Update Ruby version to a supported one, missed in previous change.
Update actions to newer versions.

---
Failed run, e.g.: https://github.com/zaproxy/zap-api-docs/actions/runs/3646890235