### PR TITLE
Link to newer Python ZAP API client

### DIFF
--- a/source/includes/welcome.md
+++ b/source/includes/welcome.md
@@ -103,7 +103,7 @@ API clients are available for the following languages:
 | Java         | [GitHub](https://github.com/zaproxy/zap-api-java/releases) [Maven Central](https://search.maven.org/search?q=g:org.zaproxy%20AND%20a:zap-clientapi&core=gav) | Official API  |
 | Node.js      | [NPM](https://www.npmjs.org/package/zaproxy) | Official API |
 | PHP          | [GitHub](https://github.com/yukisov/php-owasp-zap-v2) [Packagist](https://packagist.org/packages/zaproxy/php-owasp-zap-v2)  | In process of becoming an official API |
-| Python       | [PyPI](https://pypi.python.org/pypi/python-owasp-zap-v2.4) | Official API  |
+| Python       | [PyPI](https://pypi.python.org/pypi/zaproxy) | Official API  |
 | Ruby         | [GitHub](https://github.com/vpereira/owasp_zap) |           |
 
 ## Quick Setup Guide


### PR DESCRIPTION
Update to match the package rename to `zaproxy`.