### PR TITLE
Do not parse OTHER endpoints as JSON

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "zap-api-docs",
   "version": "1.0.0",
   "scripts": {
-    "build": "widdershins --search false --language_tabs 'shell:Shell' 'java:Java' 'python:Python' --summary openapi.yaml source/includes/apis.md"
+    "build": "widdershins -u widdershins/templates/ --search false --language_tabs 'shell:Shell' 'java:Java' 'python:Python' --summary openapi.yaml source/includes/apis.md"
   },
   "dependencies": {
     "widdershins": "^3.6.7"

--- a/widdershins/templates/code_python.dot
+++ b/widdershins/templates/code_python.dot
@@ -1,0 +1,10 @@
+import requests
+{{?data.allHeaders.length}}headers = {
+{{~data.allHeaders :p:index}}  '{{=p.name}}': {{=p.exampleValues.json}}{{?index < data.allHeaders.length-1}},{{?}}
+{{~}}}
+{{?}}
+r = requests.{{=data.method.verb}}('{{=data.url}}'{{? data.requiredParameters.length}}, params={
+{{~ data.requiredParameters :p:index}}  '{{=p.name}}': {{=p.exampleValues.json}}{{? data.requiredParameters.length-1 != index }},{{?}}{{~}}
+}{{?}}{{?data.allHeaders.length}}, headers = headers{{?}})
+
+{{?data.url.includes("/JSON/")}}print(r.json()){{?? true }}print(r.content){{?}}


### PR DESCRIPTION
Override the default Python code sample to only parse JSON for JSON endpoints, otherwise print the content of the response.

Fix #12.

---
WIP pending on #176.